### PR TITLE
Upgrade to Scala 2.13.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtassembly.AssemblyKeys.assembly
 
 lazy val akkaHttpVersion   = "10.1.12"
 lazy val akkaVersion       = "2.6.6"
-lazy val elasticApmVersion = "1.17.0"
+lazy val elasticApmVersion = "1.24.1-SNAPSHOT"
 
 resolvers += Resolver.mavenLocal
 
@@ -10,7 +10,7 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization    := "com.example",
-      scalaVersion    := "2.13.2"
+      scalaVersion    := "2.13.6"
     )),
     name := "akka-http-apm",
     libraryDependencies ++= Seq(

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,51 +1,76 @@
 version: '2.2'
+
 services:
+  apm-server:
+    image: docker.elastic.co/apm/apm-server:7.12.0
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+      kibana:
+        condition: service_healthy
+    cap_add: ["CHOWN", "DAC_OVERRIDE", "SETGID", "SETUID"]
+    cap_drop: ["ALL"]
+    ports:
+      - 8200:8200
+    networks:
+      - elastic
+    command: >
+      apm-server -e
+        -E apm-server.rum.enabled=true
+        -E setup.kibana.host=kibana:5601
+        -E setup.template.settings.index.number_of_replicas=0
+        -E apm-server.kibana.enabled=true
+        -E apm-server.kibana.host=kibana:5601
+        -E output.elasticsearch.hosts=["elasticsearch:9200"]
+    healthcheck:
+      interval: 10s
+      retries: 12
+      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:8200/
+
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0
-    container_name: elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.12.0
     environment:
-      - node.name=es01
-      - cluster.name=es-docker-cluster
-      - discovery.type=single-node
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - cluster.name=docker-cluster
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g
     ulimits:
       memlock:
-        soft: -1
         hard: -1
+        soft: -1
     volumes:
-      - data01:/usr/share/elasticsearch/data
-    ports: ['9200:9200']
-    networks: ['elastic']
+      - esdata:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - elastic
+    healthcheck:
+      interval: 20s
+      retries: 10
+      test: curl -s http://localhost:9200/_cluster/health | grep -vq '"status":"red"'
+
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.8.0
-    container_name: kibana
-    ports: ['5601:5601']
-    networks: ['elastic']
-    depends_on: ['elasticsearch']
-  apm-server:
-    image: docker.elastic.co/apm/apm-server:7.8.0
-    container_name: apm_server
-    ports: ['8200:8200']
-    networks: ['elastic']
-    command: --strict.perms=false -e  # -e flag to log to stderr and disable syslog/file output
-    #secrets:
-    #- source: apm-server.yml
-    #target: /usr/share/apm-server/apm-server.yml
-    #- source: apm-server.keystore
-    #target: /usr/share/apm-server/apm-server.keystore
-    #- source: ca.crt
-    #target: /usr/share/apm-server/certs/ca/ca.crt
-        #volumes:
-        #- './scripts/setup-beat.sh:/usr/local/bin/setup-beat.sh:ro'
-    depends_on: ['elasticsearch', 'kibana']
+    image: docker.elastic.co/kibana/kibana:7.12.0
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+    ports:
+      - 5601:5601
+    networks:
+      - elastic
+    healthcheck:
+      interval: 10s
+      retries: 20
+      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:5601/api/status
 
 volumes:
-  data01:
+  esdata:
     driver: local
 
 networks:
   elastic:
     driver: bridge
-
-

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.5.5


### PR DESCRIPTION
I've built https://github.com/elastic/apm-agent-java/pull/1918 locally and used it for your project.

From what I can tell, the post-requests are traced correctly.

The get-requests are not traced correctly due to the akka-actors. Ill check if it is still traced correctly when I remove the actors and use Futures instead.

Other apm tools specifically instrument akka-actors so I assume there is some context-switching happing there as well: https://github.com/kamon-io/Kamon/tree/master/instrumentation/kamon-akka/src/akka-2.6/scala/kamon/instrumentation/akka/instrumentations/akka_26